### PR TITLE
uio_pci_dma.c: support for kernels >4.1

### DIFF
--- a/patches/linux_uio/uio_pci_dma.c
+++ b/patches/linux_uio/uio_pci_dma.c
@@ -51,7 +51,7 @@
 #include <linux/sched.h>
 #include <linux/smp.h>
 #include <asm/cacheflush.h>
-
+#include <linux/vmalloc.h>
 
 
 #pragma GCC diagnostic pop


### PR DESCRIPTION
"include linux/vmalloc.h" was removed from include/net/inet_hashtables.h from kernel-4.1 -> kernel-4.2, leading to `error: implicit declaration of function ‘vfree’` when compiling the kernel module.
