### PR TITLE
Support for Kernel 4.5 and CentOS 7.3

### DIFF
--- a/patches/linux_uio/uio_pci_dma.c
+++ b/patches/linux_uio/uio_pci_dma.c
@@ -1068,10 +1068,14 @@ page_fault_handler
     UIO_DEBUG_ENTER();
 
     struct uio_pci_dma_private *priv = vma->vm_private_data;
-    int ret =
-        vm_insert_mixed
-            (vma, (unsigned long)vmf->virtual_address,
-                priv->pfn_list[vmf->pgoff % priv->pages]);
+
+#ifdef PDA_PFN_T_PAGES
+    int ret = vm_insert_mixed(vma, (unsigned long)vmf->virtual_address,
+                              pfn_to_pfn_t(priv->pfn_list[vmf->pgoff % priv->pages]));
+#else
+    int ret = vm_insert_mixed(vma, (unsigned long)vmf->virtual_address,
+                              priv->pfn_list[vmf->pgoff % priv->pages]);
+#endif
 
     switch(ret)
     {

--- a/patches/linux_uio/uio_pci_dma.h
+++ b/patches/linux_uio/uio_pci_dma.h
@@ -291,6 +291,27 @@ BIN_ATTR_MAP_CALLBACK( map_sg );
 /** Version dependend definitions */
 
 
+/**
+ * Kernel 4.5 introduces a different management of pages by PFN, see
+ * https://lwn.net/Articles/654396/
+ * https://lwn.net/Articles/656197/
+ * https://lwn.net/Articles/672457/
+ * These changes are back-ported at least into CentOS 7.3,
+ * kernel 3.10.0-514.6.1.el7.x86_64
+ **/
+#if defined(RHEL_RELEASE_CODE)
+#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7, 3)
+#define PDA_PFN_T_PAGES
+#endif
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
+#define PDA_PFN_T_PAGES
+#endif
+
+#ifdef PDA_PFN_T_PAGES
+#include <linux/pfn_t.h>
+#endif
 
 #endif /** __KERNEL__ */
 


### PR DESCRIPTION
Building the kernel module fails on kernel 4.5 and CentOS 7.3 kernel 3.10.0-514 with
```
uio_pci_dma.c:1079:31: error: incompatible type for argument 3 of ‘vm_insert_mixed’
[...]
include/linux/mm.h:2079:5: note: expected ‘pfn_t’ but argument is of type ‘long unsigned int’
int vm_insert_mixed(struct vm_area_struct *vma, unsigned long addr,
[...]
```

Kernel 4.5 introduces a different management of pages by PFN, see
https://lwn.net/Articles/654396/
https://lwn.net/Articles/656197/
https://lwn.net/Articles/672457/
These changes are back-ported at least into CentOS 7.3, kernel 3.10.0-514.6.1.el7.x86_64
