### PR TITLE
Fix crash on RHEL 9

### DIFF
--- a/patches/linux_uio/uio_pci_dma.c
+++ b/patches/linux_uio/uio_pci_dma.c
@@ -368,7 +368,7 @@ probe
 
         if(pci_device->resource[i].flags & IORESOURCE_MEM)
         {
-            dma_device->attr_bar[i].attr.name = kzalloc(10*sizeof(char), GFP_KERNEL);
+            dma_device->attr_bar[i].attr.name = kmalloc(10*sizeof(char), GFP_KERNEL);
             sprintf((char*)dma_device->attr_bar[i].attr.name, "bar%u", i);
 
             dma_device->attr_bar[i].size      = pci_resource_len(pci_device, i);

--- a/patches/linux_uio/uio_pci_dma.c
+++ b/patches/linux_uio/uio_pci_dma.c
@@ -368,7 +368,7 @@ probe
 
         if(pci_device->resource[i].flags & IORESOURCE_MEM)
         {
-            dma_device->attr_bar[i].attr.name = kmalloc(10*sizeof(char), GFP_KERNEL);
+            dma_device->attr_bar[i].attr.name = kzalloc(10*sizeof(char), GFP_KERNEL);
             sprintf((char*)dma_device->attr_bar[i].attr.name, "bar%u", i);
 
             dma_device->attr_bar[i].size      = pci_resource_len(pci_device, i);

--- a/patches/linux_uio/uio_pci_dma.h
+++ b/patches/linux_uio/uio_pci_dma.h
@@ -269,7 +269,7 @@ struct scatter
 
     #define BIN_ATTR_PDA(_name, _size, _mode, _read, _write, _mmap)                    \
     struct bin_attribute *attr_bin_ ## _name =                                         \
-        (struct bin_attribute*)kmalloc(sizeof(struct bin_attribute), GFP_KERNEL);      \
+        (struct bin_attribute*)kzalloc(sizeof(struct bin_attribute), GFP_KERNEL);      \
     attr_bin_ ## _name->attr.name = __stringify(_name);                                \
     attr_bin_ ## _name->attr.mode = _mode;                                             \
     attr_bin_ ## _name->size      = _size;                                             \


### PR DESCRIPTION
- avoid uninitialized struct members in case kernel-provided structs change
- in particular, fix uninitialized 'struct bin_attribute.f_mapping'