### PR TITLE
Fixes for RH9

### DIFF
--- a/arch/linux_x86_uio/dma_buffer_inc.c
+++ b/arch/linux_x86_uio/dma_buffer_inc.c
@@ -863,7 +863,16 @@ DMABuffer_free
             }
 
             if(munlock(buffer->map, buffer->length) != 0)
-            { ERROR_EXIT( errno, exit, "Buffer unlocking failed!\n" ); }
+            {
+                #ifdef PDA_SKIP_UNLOCK_FAILURE
+		    #pragma message "*** Compiling with PDA_SKIP_UNLOCK_FAILURE"
+                    // report, but continue with release procedure even if unlock fails
+                    ERROR( errno, "Buffer unlocking failed! (but releasing)\n" );
+		    if(0) { goto exit; } // fake use of exit label to avoid compiler warning
+                #else
+                    ERROR_EXIT( errno, exit, "Buffer unlocking failed!\n" );
+                #endif
+            }
 
             buffer->map = MAP_FAILED;
             persistant  = PDA_DELETE;

--- a/configure
+++ b/configure
@@ -62,6 +62,7 @@ MODPROBE_MODE="#define MODPROBE_MODE"
 PREFIX="/usr"
 DEBUG=""
 NUMA="true"
+EXTRA_DEFINES=""
 
 
 help()
@@ -73,6 +74,7 @@ help()
     echo "    --debug=<true|false>"
     echo "    --numa=<true|false>"
     echo "    --modprobe=<true|false>"
+    echo "    --extra=<additional defines, comma separated>"
 }
 
 
@@ -119,6 +121,11 @@ do
             fi
             continue
 	;;
+
+        "--extra" )
+	    EXTRA_DEFINES=$VALUE
+            continue
+        ;;
 
         *          )
             echo "Unknown parameter $PARAMETER!"
@@ -233,6 +240,12 @@ gen_config()
     echo "$KMOD_AVAIL"                         >> $BUILD_PATH/src/config.h
     echo "$NUMA_AVAIL"                         >> $BUILD_PATH/src/config.h
     echo "$MODPROBE_MODE"                      >> $BUILD_PATH/src/config.h
+
+    for DEF in ${EXTRA_DEFINES//,/ }
+    do
+      echo "#define $DEF"                      >> $BUILD_PATH/src/config.h
+    done
+
     echo "#endif  /* CONFIG_H */"              >> $BUILD_PATH/src/config.h
 }
 

--- a/patches/linux_uio/uio_pci_dma.h
+++ b/patches/linux_uio/uio_pci_dma.h
@@ -318,6 +318,19 @@ BIN_ATTR_MAP_CALLBACK( map_sg );
 #endif
 
 /**
+  RH 9.6 includes a kernel with interface changes.
+  It is still named 5.14.0 (release 570.16.1) but includes backports, and needs the updates desribed below
+  as for get_user_pages() 6.5.0 and MAX_PAGE_ORDER 6.8.0
+  RH 9.5 still has the previous interface.
+ **/
+#ifdef RHEL_RELEASE_CODE
+  #if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 6)
+    #define RHEL_FIX_KERNEL_202505
+  #endif
+#endif
+
+
+/**
  * Kernel 4.6 introduced six-argument get_user_pages()
  * https://github.com/torvalds/linux/commit/c12d2da56d0e07d230968ee2305aaa86b93a6832
  *
@@ -328,7 +341,7 @@ BIN_ATTR_MAP_CALLBACK( map_sg );
  * Kernel 6.5 removes unused vmas parameter from get_user_pages()
  * https://github.com/torvalds/linux/commit/54d020692b342f7bd02d7f5795fb5c401caecfcc
  **/
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0) || defined(RHEL_FIX_KERNEL_202505)
 #define PDA_FOURARG_GUP
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
 #define PDA_FIVEARG_GUP
@@ -343,7 +356,7 @@ BIN_ATTR_MAP_CALLBACK( map_sg );
  * Kernel 6.8 renames MAX_ORDER to MAX_PAGE_ORDER
  * https://github.com/torvalds/linux/commit/5e0a760b44417f7cadd79de2204d6247109558a0
  **/
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0) || defined(RHEL_FIX_KERNEL_202505)
 #define PDA_MAX_PAGE_ORDER_RENAMED
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
 #define PDA_MAX_PAGE_ORDER_INCLUSIVE

--- a/patches/linux_uio/uio_pci_dma.h
+++ b/patches/linux_uio/uio_pci_dma.h
@@ -325,10 +325,9 @@ BIN_ATTR_MAP_CALLBACK( map_sg );
  **/
 #ifdef RHEL_RELEASE_CODE
   #if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 6)
-    #define RHEL_FIX_KERNEL_202505
+    #define RHEL_RELEASE_9_6
   #endif
 #endif
-
 
 /**
  * Kernel 4.6 introduced six-argument get_user_pages()
@@ -341,7 +340,7 @@ BIN_ATTR_MAP_CALLBACK( map_sg );
  * Kernel 6.5 removes unused vmas parameter from get_user_pages()
  * https://github.com/torvalds/linux/commit/54d020692b342f7bd02d7f5795fb5c401caecfcc
  **/
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0) || defined(RHEL_FIX_KERNEL_202505)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0) || defined(RHEL_RELEASE_9_6)
 #define PDA_FOURARG_GUP
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
 #define PDA_FIVEARG_GUP
@@ -356,7 +355,7 @@ BIN_ATTR_MAP_CALLBACK( map_sg );
  * Kernel 6.8 renames MAX_ORDER to MAX_PAGE_ORDER
  * https://github.com/torvalds/linux/commit/5e0a760b44417f7cadd79de2204d6247109558a0
  **/
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0) || defined(RHEL_FIX_KERNEL_202505)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0) || defined(RHEL_RELEASE_9_6)
 #define PDA_MAX_PAGE_ORDER_RENAMED
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
 #define PDA_MAX_PAGE_ORDER_INCLUSIVE


### PR DESCRIPTION
- Updated kernel compile options for RH 9.6 (kernel 5.14.0-503.40 has some back-ported features of 6.x)
- DMABuffer_free(): added compile-time option to force buffer release if unlock fails (seen with RH9.5 and O2 software)
- configure: added --extra option to add more #define in config.h (comma-separated list).
 
These changes allow PDA to work with RH9.6 and O2 using ```./configure --extra=PDA_SKIP_UNLOCK_FAILURE```